### PR TITLE
Allow falsy defaults and bool types in config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "6"

--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ function get(key) {
         return parseValue(value, type)
     }
 
-    if (configOpts[key] && configOpts[key]['default']) {
+    if (configOpts[key] && typeof configOpts[key]['default'] !== 'undefined' ) {
         return configOpts[key]['default']
     }
 
@@ -27,12 +27,17 @@ function get(key) {
 }
 
 function parseValue(value, type) {
-    if (type == 'string') {
-        return value + ''
-    } else if (type == 'int' || type == 'integer') {
-        return parseInt(value)
-    } else if (type == 'float') {
-        return parseFloat(value)
+    switch(type) {
+        case 'string':
+            return value + ''
+        case 'int':
+        case 'integer':
+            return parseInt(value)
+        case 'float':
+            return parseFloat(value)
+        case 'boolean':
+            return !!value
+        default:
+            return value
     }
-    return value
 }

--- a/test/main.js
+++ b/test/main.js
@@ -19,13 +19,17 @@ describe('node-base-app', () => {
                 STRING_DEFAULT_OVERRIDDEN: { type: 'string', default: 'hello' },
                 STRING_OVERRIDDEN: { type: 'string' },
                 ZERO_NUMBER: { type: 'integer', default: 0 },
-                ONE_NUMBER: { type: 'integer', default: 1 }
+                ONE_NUMBER: { type: 'integer', default: 1 },
+                POSITIVE_BOOLEAN: { type: 'boolean', default: true },
+                NEGATIVE_BOOLEAN: { type: 'boolean', default: false },
+                BOOLEAN_OVERRIDDEN: { type: 'boolean' }
             })
 
-            process.env.NUMBER_DEFAULTED_OVERRIDDEN = 8
-            process.env.NUMBER_OVERRIDDEN = 9
+            process.env.NUMBER_DEFAULTED_OVERRIDDEN = '8'
+            process.env.NUMBER_OVERRIDDEN = '9'
             process.env.STRING_DEFAULTED_OVERRIDDEN = 'foo'
             process.env.STRING_OVERRIDDEN = 'bar'
+            process.env.BOOLEAN_OVERRIDDEN = true
         })
 
         it('can define default config for number type', () => {
@@ -35,6 +39,28 @@ describe('node-base-app', () => {
         it('can provide the overriden config for number type', () => {
             assert.equal(config.get('NUMBER_DEFAULTED_OVERRIDDEN'), 8)
         })
+
+        it('can define falsy values as default', () => {
+            assert.equal(config.get('ZERO_NUMBER'), 0)
+        });
+
+        it('throws an error when attempting to access a variable with no defined value', () => {
+            assert.throws(() => {
+                config.get('NUMBER')
+            }, Error);
+        });
+
+        it('can define a default config for a boolean type', () => {
+            assert.equal(config.get('POSITIVE_BOOLEAN'), true)
+        });
+
+        it('can provide an overridden boolean as a string', () => {
+            assert.equal(config.get('BOOLEAN_OVERRIDDEN'), true)
+        });
+
+        it('can define a falsy boolean as a default', () => {
+            assert.equal(config.get('NEGATIVE_BOOLEAN'), false)
+        });
     })
 
 })


### PR DESCRIPTION
Also included .travis.yml for running automated tests against updates. This needs setting up in [travis](https://travis-ci.org) though for it to work. I'd like @JamesBarwell to merge this right now and also to set up the travis integration.