### PR TITLE
Fix time sampling so that it includes the second component of process.hrtime

### DIFF
--- a/timers.js
+++ b/timers.js
@@ -28,7 +28,8 @@ module.exports = () => {
      * @returns {Integer} Elapsed time in milliseconds
      */
     function stop(label) {
-        const elapsed = process.hrtime(startHrTimes[label])[1] / 1000000 // Divide by a million to get nano to milli
+        const time = process.hrtime(base.startHrTimes[label])
+        const elapsed = (time[0] * 1e9 + time[1]) / 1000000 // add tuple seconds component to nanosecond component and divide by a million to get nano to milli
         startHrTimes[label] = process.hrtime() // Reset the timer
 
         // TODO -- Right now node-app-base doesn't support floating point values for metrics so we must convert them to integers.


### PR DESCRIPTION
Tiny but important fix to ensure the timediff samples obtained by `process.hrtime` are fully extracted. Before we were using just the nanoseconds component of the tuple and ignoring the seconds component.

See [the docs for more info](https://nodejs.org/api/process.html#process_process_hrtime_time).